### PR TITLE
chore: reconnection hardening

### DIFF
--- a/examples/http_demo_signalk_org.ts
+++ b/examples/http_demo_signalk_org.ts
@@ -4,4 +4,4 @@ import { Client, RootData } from "@signalk/client-ts";
 const client = new Client({ host: "demo.signalk.org" });
 client.rootData()
   .then((rootData: RootData) => console.log(rootData))
-  .catch((err) => console.error(err));
+  .catch((err) => console.error(err.message));

--- a/examples/http_token_auth.ts
+++ b/examples/http_token_auth.ts
@@ -9,7 +9,7 @@ client
     console.log(loginResult);
     return fetchSomeStuff(client);
   })
-  .catch((err) => console.error(err));
+  .catch((err) => console.error(err.message));
 
 const fetchSomeStuff = (client: Client) =>
   client

--- a/examples/login_error.ts
+++ b/examples/login_error.ts
@@ -4,4 +4,4 @@ import { Client, LoginResult } from "@signalk/client-ts";
 const client = new Client({ host: "localhost", port: 3000 });
 client.login({ username: "admin", password: "adminnnnnn" })
   .then((lr: LoginResult) => console.log(lr)) //never called
-  .catch((err) => console.error(err));
+  .catch((err) => console.error(err.message));

--- a/examples/ws_closed_port_connection.ts
+++ b/examples/ws_closed_port_connection.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env ts-node
 import { Client, RootData, LoginResult } from "@signalk/client-ts";
-console.log("connet to demo.signalk.org websocket during 2 seconds.")
+console.log("tries to connet on closed port during 5 seconds.")
 console.log("To display debug messages set DEBUG=signalk-client-ts");
 
-const client = new Client({ host: "demo.signalk.org" });
+const client = new Client({
+  host: "localhost",
+  port: 0, // closed port connection
+  reconnect: true
+});
 client.on("hello", (h) => console.log("onHello ",h));
 client.on("delta", (d) => console.log("onDelta ",d));
 client.on("connect", () => console.log("onConnect"));
@@ -14,8 +18,9 @@ client
   .connect()
   .then((x) =>
     setTimeout(
-      () => client.disconnect().then(() => console.log("2 seconds overrun, disconnect")),
-      2000
+      () => client.disconnect().then(() => console.log("5 seconds overrun, abort")),
+      5000
     )
   )
   .catch((e) => console.error(e.message));
+

--- a/examples/ws_unresponsive_port_connection.ts
+++ b/examples/ws_unresponsive_port_connection.ts
@@ -1,21 +1,31 @@
 #!/usr/bin/env ts-node
 import { Client, RootData, LoginResult } from "@signalk/client-ts";
-console.log("connet to demo.signalk.org websocket during 2 seconds.")
+console.log("tries to connect on unresponsive port during 30 seconds.")
+console.log("The network timeout is set of 5 seconds.");
+console.log("Be patient and wait for the error message...");
 console.log("To display debug messages set DEBUG=signalk-client-ts");
 
-const client = new Client({ host: "demo.signalk.org" });
+const client = new Client({
+  host: "demo.signalk.org",
+  port: 81, // unresponsive port connection
+  reconnect: true,
+  idleTimeout: -1
+});
+
 client.on("hello", (h) => console.log("onHello ",h));
 client.on("delta", (d) => console.log("onDelta ",d));
 client.on("connect", () => console.log("onConnect"));
 client.on("open", () => console.log("onOpen"));
 client.on("error", (e) => console.log("onError ",e.message));
 client.on("connecting", () => console.log("onConnecting"));
+
+
 client
   .connect()
   .then((x) =>
     setTimeout(
-      () => client.disconnect().then(() => console.log("2 seconds overrun, disconnect")),
-      2000
+      () => client.disconnect().then(() => console.log("30 seconds overrun, abort")),
+      30000
     )
   )
   .catch((e) => console.error(e.message));

--- a/examples/ws_with_login.ts
+++ b/examples/ws_with_login.ts
@@ -12,4 +12,4 @@ client
   .then(() => {
     console.log("connected");
   })
-  .catch((e) => console.error(e));
+  .catch((e) => console.error(e.message));

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
   "author": "Teppo Kurki",
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "^3.9.2",
+    "typescript": "^3.9.3",
     "ts-node": "^8.10.1",
     "@types/isomorphic-fetch": "0.0.35",
     "@types/node-fetch": "^2.5.7",
     "@types/tough-cookie": "^4.0.0",
-    "@types/ws": "^7.2.4"
+    "@types/ws": "^7.2.4",
+    "@types/debug": "^4.1.5"
   },
   "dependencies": {
     "es6-promise": "^4.2.8",
@@ -25,6 +26,7 @@
     "isomorphic-fetch": "^2.2.1",
     "isomorphic-ws": "^4.0.1",
     "tough-cookie": "^4.0.0",
-    "ws": "^7.3.0"
+    "ws": "^7.3.0",
+    "debug": "^4.1.1"
   }
 }


### PR DESCRIPTION
- Add management of reconnection cases on a closed port
- Add client option idleTimeout with -1 for no timeout
- Add debug package `signalk-client-ts` & `signalk-client-ts:data`
- Add hard coded fetch timeout set to 5 seconds
- Add `connecting` event
- Add examples with connection errors
